### PR TITLE
Simplify some deserialization code.

### DIFF
--- a/FrequentFlyer/Authentication/AuthMethodDataDeserializer.swift
+++ b/FrequentFlyer/Authentication/AuthMethodDataDeserializer.swift
@@ -3,22 +3,17 @@ import RxSwift
 
 class AuthMethodDataDeserializer {
     func deserialize(_ data: Data) -> Observable<[AuthMethod]> {
-        var authMethodsJSONObject: Any?
-        do {
-            authMethodsJSONObject = try JSONSerialization.jsonObject(with: data, options: .allowFragments)
-        } catch { }
-
-        var authMethods = [AuthMethod]()
+        let authMethodsJSONObject = try? JSONSerialization.jsonObject(with: data, options: .allowFragments)
 
         guard let authMethodsJSON = authMethodsJSONObject as? Array<NSDictionary> else {
             return Observable.error(DeserializationError(details: "Could not interpret data as JSON dictionary", type: .invalidInputFormat))
         }
-
-        for authMethodsDictionary in authMethodsJSON {
-            guard let typeString = authMethodsDictionary["type"] as? String else { continue }
-            guard let displayNameString = authMethodsDictionary["display_name"] as? String else { continue }
-            guard let urlString = authMethodsDictionary["auth_url"] as? String else { continue }
-
+        
+        let authMethods = authMethodsJSON.flatMap { authMethodsDictionary -> AuthMethod? in
+            guard let typeString = authMethodsDictionary["type"] as? String else { return nil }
+            guard let displayNameString = authMethodsDictionary["display_name"] as? String else { return nil }
+            guard let urlString = authMethodsDictionary["auth_url"] as? String else { return nil }
+            
             var type = AuthType.basic
             if typeString == "basic" && displayNameString == AuthMethod.DisplayNames.basic {
                 type = .basic
@@ -27,10 +22,10 @@ class AuthMethodDataDeserializer {
             } else if typeString == "oauth" && displayNameString == AuthMethod.DisplayNames.uaa {
                 type = .uaa
             } else {
-                continue
+                return nil
             }
-
-            authMethods.append(AuthMethod(type: type, displayName: displayNameString, url: urlString))
+            
+            return AuthMethod(type: type, displayName: displayNameString, url: urlString)
         }
 
         return Observable.from(optional: authMethods)

--- a/FrequentFlyer/Authentication/TeamsDataDeserializer.swift
+++ b/FrequentFlyer/Authentication/TeamsDataDeserializer.swift
@@ -5,21 +5,14 @@ import RxSwift
 
 class TeamsDataDeserializer {
     func deserialize(_ data: Data) -> Observable<[String]> {
-        var teamsJSONObject: Any?
-        do {
-            teamsJSONObject = try JSONSerialization.jsonObject(with: data, options: .allowFragments)
-        } catch { }
-
-        var teamNames = [String]()
+        let teamsJSONObject = try? JSONSerialization.jsonObject(with: data, options: .allowFragments)
 
         guard let teamsJSON = teamsJSONObject as? Array<NSDictionary> else {
             return Observable.error(DeserializationError(details: "Could not interpret data as JSON dictionary", type: .invalidInputFormat))
         }
-
-        for teamsDictionary in teamsJSON {
-            guard let nameString = teamsDictionary["name"] as? String else { continue }
-
-            teamNames.append(nameString)
+        
+        let teamNames = teamsJSON.flatMap { teamsDictionary in
+            return teamsDictionary["name"] as? String
         }
 
         return Observable.from(optional: teamNames)

--- a/FrequentFlyer/Authentication/TokenDataDeserializer.swift
+++ b/FrequentFlyer/Authentication/TokenDataDeserializer.swift
@@ -2,30 +2,21 @@ import Foundation
 import RxSwift
 
 class TokenDataDeserializer {
-    func deserialize(_ tokenData: Data) -> ReplaySubject<Token> {
-        let $ = ReplaySubject<Token>.createUnbounded()
-
-        var tokenDataJSONObject: Any?
-        do {
-            tokenDataJSONObject = try JSONSerialization.jsonObject(with: tokenData, options: .allowFragments)
-        } catch { }
+    func deserialize(_ tokenData: Data) -> Observable<Token> {
+        let tokenDataJSONObject = try? JSONSerialization.jsonObject(with: tokenData, options: .allowFragments)
 
         guard let tokenDataDictionary = tokenDataJSONObject as? NSDictionary else {
-            $.onError(DeserializationError(details: "Could not interpret data as JSON dictionary", type: .invalidInputFormat))
-            return $
+            return Observable.error(DeserializationError(details: "Could not interpret data as JSON dictionary", type: .invalidInputFormat))
         }
 
         guard tokenDataDictionary.value(forKey: "value") != nil else {
-            $.onError(DeserializationError(details: "Missing required 'value' key", type: .missingRequiredData))
-            return $
+            return Observable.error(DeserializationError(details: "Missing required 'value' key", type: .missingRequiredData))
         }
 
         guard let tokenValue = tokenDataDictionary["value"] as? String else {
-            $.onError(DeserializationError(details: "Expected value for 'value' key to be a string", type: .typeMismatch))
-            return $
+            return Observable.error(DeserializationError(details: "Expected value for 'value' key to be a string", type: .typeMismatch))
         }
 
-        $.onNext(Token(value: tokenValue))
-        return $
+        return Observable.just(Token(value: tokenValue))
     }
 }

--- a/FrequentFlyer/Builds/BuildDataDeserializer.swift
+++ b/FrequentFlyer/Builds/BuildDataDeserializer.swift
@@ -4,10 +4,7 @@ class BuildDataDeserializer {
     var buildStatusInterpreter = BuildStatusInterpreter()
 
     func deserialize(_ data: Data) -> (build: Build?, error: DeserializationError?) {
-        var buildJSONObject: Any?
-        do {
-            buildJSONObject = try JSONSerialization.jsonObject(with: data, options: .allowFragments)
-        } catch { }
+        let buildJSONObject = try? JSONSerialization.jsonObject(with: data, options: .allowFragments)
 
         guard let buildJSON = buildJSONObject as? NSDictionary else {
             return (nil, DeserializationError(details: "Could not interpret data as JSON dictionary", type: .invalidInputFormat))
@@ -66,23 +63,13 @@ class BuildDataDeserializer {
         }
 
         let startTimeObject = buildJSON.value(forKey: "start_time")
-        var startTime: UInt? = nil
-        if startTimeObject != nil {
-            guard let castedStartTime = startTimeObject as? UInt else {
-                return typeMismatchErrorCaseForKey("start_time", expectedType: "an unsigned integer")
-            }
-
-            startTime = castedStartTime
+        guard let startTime = startTimeObject as? UInt else {
+            return typeMismatchErrorCaseForKey("start_time", expectedType: "an unsigned integer")
         }
 
         let endTimeObject = buildJSON.value(forKey: "end_time")
-        var endTime: UInt? = nil
-        if endTimeObject != nil {
-            guard let castedEndTime = endTimeObject as? UInt else {
-                return typeMismatchErrorCaseForKey("end_time", expectedType: "an unsigned integer")
-            }
-
-            endTime = castedEndTime
+        guard let endTime = endTimeObject as? UInt else {
+            return typeMismatchErrorCaseForKey("end_time", expectedType: "an unsigned integer")
         }
 
         let build = Build(id: id,

--- a/FrequentFlyer/Builds/BuildsDataDeserializer.swift
+++ b/FrequentFlyer/Builds/BuildsDataDeserializer.swift
@@ -11,15 +11,10 @@ class BuildsDataDeserializer {
             return (nil, DeserializationError(details: "Could not interpret data as JSON dictionary", type: .invalidInputFormat))
         }
 
-        var builds = [Build]()
-        for nextBuildJSON in buildsJSONObject.arrayValue {
-            do {
-                let nextBuildJSONData = try nextBuildJSON.rawData(options: .prettyPrinted)
-                let deserializeResult = buildDataDeserializer.deserialize(nextBuildJSONData)
-                if let build = deserializeResult.build {
-                    builds.append(build)
-                }
-            } catch {}
+        let builds = buildsJSONObject.arrayValue.flatMap { nextBuildJSON -> Build? in
+            guard let nextBuildJSONData = try? nextBuildJSON.rawData(options: .prettyPrinted) else { return nil }
+            
+            return buildDataDeserializer.deserialize(nextBuildJSONData).build
         }
 
         return (builds, nil)

--- a/FrequentFlyer/Jobs/JobsDataDeserializer.swift
+++ b/FrequentFlyer/Jobs/JobsDataDeserializer.swift
@@ -5,50 +5,28 @@ class JobsDataDeserializer {
     var buildDataDeserializer = BuildDataDeserializer()
 
     func deserialize(_ data: Data) -> Observable<[Job]> {
-        var jobsJSONObject: Any?
-        do {
-            jobsJSONObject = try JSONSerialization.jsonObject(with: data, options: .allowFragments)
-        } catch { }
-
-        var jobs = [Job]()
+        let jobsJSONObject = try? JSONSerialization.jsonObject(with: data, options: .allowFragments)
 
         guard let jobsJSON = jobsJSONObject as? Array<NSDictionary> else {
             return Observable.error(DeserializationError(details: "Could not interpret data as JSON dictionary", type: .invalidInputFormat))
         }
-
-        for jobsDictionary in jobsJSON {
-            guard let name = jobsDictionary["name"] as? String else { continue }
-            guard let groups = jobsDictionary["groups"] as? Array<String> else { continue }
-
-            let finishedBuildJSON = jobsDictionary["finished_build"] as? NSDictionary
-            let nextBuildJSON = jobsDictionary["next_build"] as? NSDictionary
-
-            if finishedBuildJSON == nil && nextBuildJSON == nil { continue }
-
-            var finishedBuild: Build? = nil
-            if let finishedBuildJSON = finishedBuildJSON {
-                do {
-
-                    let finishedBuildData = try JSONSerialization.data(withJSONObject: finishedBuildJSON, options: .prettyPrinted)
-                    finishedBuild = buildDataDeserializer.deserialize(finishedBuildData).build
-                } catch { }
-            }
-
-            var nextBuild: Build? = nil
-            if let nextBuildJSON = nextBuildJSON {
-                do {
-
-                    let nextBuildData = try JSONSerialization.data(withJSONObject: nextBuildJSON, options: .prettyPrinted)
-                    nextBuild = buildDataDeserializer.deserialize(nextBuildData).build
-                } catch { }
-            }
-
-
-            jobs.append(
-                Job(name: name, nextBuild: nextBuild, finishedBuild: finishedBuild, groups: groups)
-            )
+        
+        let jobs = jobsJSON.flatMap { jobsDictionary -> Job? in
+            guard let name = jobsDictionary["name"] as? String else { return nil }
+            guard let groups = jobsDictionary["groups"] as? Array<String> else { return nil }
+            
+            guard let finishedBuildJSON = jobsDictionary["finished_build"] as? NSDictionary else { return nil }
+            guard let nextBuildJSON = jobsDictionary["next_build"] as? NSDictionary else { return nil }
+            
+            let finishedBuildData = try? JSONSerialization.data(withJSONObject: finishedBuildJSON, options: .prettyPrinted)
+            let finishedBuild = finishedBuildData.flatMap { buildDataDeserializer.deserialize($0).build }
+            
+            let nextBuildData = try? JSONSerialization.data(withJSONObject: nextBuildJSON, options: .prettyPrinted)
+            let nextBuild = nextBuildData.flatMap { buildDataDeserializer.deserialize($0).build }
+            
+            return Job(name: name, nextBuild: nextBuild, finishedBuild: finishedBuild, groups: groups)
         }
-
+        
         return Observable.from(optional: jobs)
     }
 }

--- a/FrequentFlyer/Logs/SSEMessageEventParser.swift
+++ b/FrequentFlyer/Logs/SSEMessageEventParser.swift
@@ -4,10 +4,7 @@ import EventSource
 class SSEMessageEventParser {
     func parseConcourseEventFromSSEMessageEvent(event: SSEMessageEvent) -> (log: LogEvent?, error: FFError?) {
         let eventJSONData = event.data.data(using: String.Encoding.utf8)
-        var eventJSONAny: Any?
-        do {
-            eventJSONAny = try JSONSerialization.jsonObject(with: eventJSONData!, options: .allowFragments)
-        } catch {
+        guard let eventJSONAny = try? JSONSerialization.jsonObject(with: eventJSONData!, options: .allowFragments) else {
             return (nil, BasicError(details: "Could not parse event: Input SSEMessageEvent data is not valid JSON"))
         }
 

--- a/FrequentFlyer/Pipeline/PipelineDataDeserializer.swift
+++ b/FrequentFlyer/Pipeline/PipelineDataDeserializer.swift
@@ -2,21 +2,17 @@ import Foundation
 
 class PipelineDataDeserializer {
     func deserialize(_ data: Data) -> (pipelines: [Pipeline]?, error: DeserializationError?) {
-        var pipelinesJSONObject: Any?
-        do {
-            pipelinesJSONObject = try JSONSerialization.jsonObject(with: data, options: .allowFragments)
-        } catch { }
-
-        guard let pipelinesJSON = pipelinesJSONObject as? Array<NSDictionary> else {
+        let pipelinesJSONObject = try? JSONSerialization.jsonObject(with: data, options: .allowFragments)
+        
+        guard let pipelinesJSONArray = pipelinesJSONObject as? Array<NSDictionary> else {
             return (nil, DeserializationError(details: "Could not interpret data as JSON dictionary", type: .invalidInputFormat))
         }
-
-        var pipelines = [Pipeline]()
-        for pipelineDictionary in pipelinesJSON {
-            guard let pipelineName = pipelineDictionary["name"] as? String else { continue }
-            pipelines.append(Pipeline(name: pipelineName))
+        
+        let pipelines = pipelinesJSONArray.flatMap { pipelineDictionary -> Pipeline? in
+            guard let pipelineName = pipelineDictionary["name"] as? String else { return nil }
+            return Pipeline(name: pipelineName)
         }
-
+        
         return (pipelines, nil)
     }
 }

--- a/FrequentFlyerTests/Authentication/AuthMethodsServiceSpec.swift
+++ b/FrequentFlyerTests/Authentication/AuthMethodsServiceSpec.swift
@@ -30,10 +30,8 @@ class AuthMethodsServiceSpec: QuickSpec {
                 capturedData = data
                 if let error = toReturnDeserializationError {
                     return Observable.error(error)
-                } else if let authMethods = toReturnAuthMethods {
-                    return Observable.just(authMethods)
                 } else {
-                    return Observable.empty()
+                    return Observable.from(optional: toReturnAuthMethods)
                 }
             }
         }

--- a/FrequentFlyerTests/Authentication/AuthMethodsServiceSpec.swift
+++ b/FrequentFlyerTests/Authentication/AuthMethodsServiceSpec.swift
@@ -28,16 +28,13 @@ class AuthMethodsServiceSpec: QuickSpec {
 
             override func deserialize(_ data: Data) -> Observable<[AuthMethod]> {
                 capturedData = data
-                let subject = ReplaySubject<[AuthMethod]>.createUnbounded()
                 if let error = toReturnDeserializationError {
-                    subject.onError(error)
+                    return Observable.error(error)
+                } else if let authMethods = toReturnAuthMethods {
+                    return Observable.just(authMethods)
                 } else {
-                    if let authMethods = toReturnAuthMethods {
-                        subject.onNext(authMethods)
-                    }
-                    subject.onCompleted()
+                    return Observable.empty()
                 }
-                return subject
             }
         }
 

--- a/FrequentFlyerTests/Authentication/BasicAuthTokenServiceSpec.swift
+++ b/FrequentFlyerTests/Authentication/BasicAuthTokenServiceSpec.swift
@@ -28,10 +28,8 @@ class BasicAuthTokenServiceSpec: QuickSpec {
                 capturedTokenData = data
                 if let error = toReturnDeserializationError {
                     return Observable.error(error)
-                } else if let token = toReturnToken {
-                    return Observable.just(token)
                 } else {
-                    return Observable.empty()
+                    return Observable.from(optional: toReturnToken)
                 }
             }
         }

--- a/FrequentFlyerTests/Authentication/BasicAuthTokenServiceSpec.swift
+++ b/FrequentFlyerTests/Authentication/BasicAuthTokenServiceSpec.swift
@@ -24,18 +24,15 @@ class BasicAuthTokenServiceSpec: QuickSpec {
             var toReturnToken: Token?
             var toReturnDeserializationError: DeserializationError?
 
-            override func deserialize(_ data: Data) -> ReplaySubject<Token> {
+            override func deserialize(_ data: Data) -> Observable<Token> {
                 capturedTokenData = data
-                let subject = ReplaySubject<Token>.createUnbounded()
                 if let error = toReturnDeserializationError {
-                    subject.onError(error)
+                    return Observable.error(error)
+                } else if let token = toReturnToken {
+                    return Observable.just(token)
                 } else {
-                    if let token = toReturnToken {
-                        subject.onNext(token)
-                    }
-                    subject.onCompleted()
+                    return Observable.empty()
                 }
-                return subject
             }
         }
 

--- a/FrequentFlyerTests/Authentication/TeamListServiceSpec.swift
+++ b/FrequentFlyerTests/Authentication/TeamListServiceSpec.swift
@@ -28,10 +28,8 @@ class TeamListServiceSpec: QuickSpec {
             capturedData = data
             if let error = toReturnDeserializationError {
                 return Observable.error(error)
-            } else if let teams = toReturnTeams {
-                return Observable.just(teams)
             } else {
-                return Observable.empty()
+                return Observable.from(optional: toReturnTeams)
             }
         }
     }

--- a/FrequentFlyerTests/Authentication/TeamListServiceSpec.swift
+++ b/FrequentFlyerTests/Authentication/TeamListServiceSpec.swift
@@ -26,16 +26,13 @@ class TeamListServiceSpec: QuickSpec {
 
         override func deserialize(_ data: Data) -> Observable<[String]> {
             capturedData = data
-            let subject = ReplaySubject<[String]>.createUnbounded()
             if let error = toReturnDeserializationError {
-                subject.onError(error)
+                return Observable.error(error)
+            } else if let teams = toReturnTeams {
+                return Observable.just(teams)
             } else {
-                if let teams = toReturnTeams {
-                    subject.onNext(teams)
-                }
-                subject.onCompleted()
+                return Observable.empty()
             }
-            return subject
         }
     }
 

--- a/FrequentFlyerTests/Authentication/TokenDataDeserializerSpec.swift
+++ b/FrequentFlyerTests/Authentication/TokenDataDeserializerSpec.swift
@@ -14,7 +14,7 @@ class TokenDataDeserializerSpec: QuickSpec {
             }
 
             describe("Deserializing valid token data") {
-                var deserialization$: ReplaySubject<Token>!
+                var deserialization$: Observable<Token>!
                 var result: StreamResult<Token>!
 
                 context("For data originating as a dictionary") {
@@ -59,7 +59,7 @@ class TokenDataDeserializerSpec: QuickSpec {
             }
 
             describe("Deserializing invalid token data") {
-                var deserialization$: ReplaySubject<Token>!
+                var deserialization$: Observable<Token>!
                 var result: StreamResult<Token>!
 
                 context("Missing 'value' key") {

--- a/FrequentFlyerTests/Authentication/UnauthenticatedTokenServiceSpec.swift
+++ b/FrequentFlyerTests/Authentication/UnauthenticatedTokenServiceSpec.swift
@@ -25,18 +25,15 @@ class UnauthenticatedTokenServiceSpec: QuickSpec {
             var toReturnToken: Token?
             var toReturnDeserializationError: DeserializationError?
 
-            override func deserialize(_ data: Data) -> ReplaySubject<Token> {
+            override func deserialize(_ data: Data) -> Observable<Token> {
                 capturedTokenData = data
-                let subject = ReplaySubject<Token>.createUnbounded()
                 if let error = toReturnDeserializationError {
-                    subject.onError(error)
+                    return Observable.error(error)
+                } else if let token = toReturnToken {
+                    return Observable.just(token)
                 } else {
-                    if let token = toReturnToken {
-                        subject.onNext(token)
-                    }
-                    subject.onCompleted()
+                    return Observable.empty()
                 }
-                return subject
             }
         }
 

--- a/FrequentFlyerTests/Authentication/UnauthenticatedTokenServiceSpec.swift
+++ b/FrequentFlyerTests/Authentication/UnauthenticatedTokenServiceSpec.swift
@@ -29,10 +29,8 @@ class UnauthenticatedTokenServiceSpec: QuickSpec {
                 capturedTokenData = data
                 if let error = toReturnDeserializationError {
                     return Observable.error(error)
-                } else if let token = toReturnToken {
-                    return Observable.just(token)
                 } else {
-                    return Observable.empty()
+                    return Observable.from(optional: toReturnToken)
                 }
             }
         }

--- a/FrequentFlyerTests/Jobs/JobsServiceSpec.swift
+++ b/FrequentFlyerTests/Jobs/JobsServiceSpec.swift
@@ -29,10 +29,8 @@ class JobsServiceSpec: QuickSpec {
                 capturedData = data
                 if let error = toReturnDeserializationError {
                     return Observable.error(error)
-                } else if let jobs = toReturnJobs {
-                    return Observable.just(jobs)
                 } else {
-                    return Observable.empty()
+                    return Observable.from(optional: toReturnJobs)
                 }
             }
         }

--- a/FrequentFlyerTests/Jobs/JobsServiceSpec.swift
+++ b/FrequentFlyerTests/Jobs/JobsServiceSpec.swift
@@ -27,16 +27,13 @@ class JobsServiceSpec: QuickSpec {
 
             override func deserialize(_ data: Data) -> Observable<[Job]> {
                 capturedData = data
-                let subject = ReplaySubject<[Job]>.createUnbounded()
                 if let error = toReturnDeserializationError {
-                    subject.onError(error)
+                    return Observable.error(error)
+                } else if let jobs = toReturnJobs {
+                    return Observable.just(jobs)
                 } else {
-                    if let jobs = toReturnJobs {
-                        subject.onNext(jobs)
-                    }
-                    subject.onCompleted()
+                    return Observable.empty()
                 }
-                return subject
             }
         }
 


### PR DESCRIPTION
I noticed some issues that I think this PR rectifies:
1. TokenDataSerializer was returning a ReplaySubject, which is way more implementation detail than needs to be exposed in the public interface
2. TokenDataSerializer doesn't actually need a ReplaySubject. It can accomplish the same thing by returning Observable.just() or Observable.error() as needed. This is a good practice in general, as it's easier for subjects to accidentally violate the observable contract.
3. A lot of the deserialization code had a `do` with an empty `catch` block, then assigned the result of the call to an optionally typed variable outside of the do/catch. You can accomplish the same thing more concisely and clearly with Swift's `try?` syntax.

I also replaced some for loops with some functional code (mostly just flatMaps). Not that there was really anything wrong with the for loops, I just think the functional version is nicer. I hope you agree! :)