### PR TITLE
Use RxCocoa’s built in extension on URLSession in the HTTPClient

### DIFF
--- a/FrequentFlyer/HTTP/HTTPClient.swift
+++ b/FrequentFlyer/HTTP/HTTPClient.swift
@@ -13,8 +13,14 @@ class HTTPClient {
 
     func perform(request: URLRequest) -> Observable<HTTPResponse> {
         return session.rx.response(request: request)
+            .do(onSubscribed: {
+                UIApplication.shared.isNetworkActivityIndicatorVisible = true
+            })
             .map { response, data in
                 return HTTPResponseImpl(body: data, statusCode: response.statusCode)
             }
+            .do(onCompleted: {
+                UIApplication.shared.isNetworkActivityIndicatorVisible = false
+            })
     }
 }

--- a/FrequentFlyerTests/HTTP/HTTPClientSpec.swift
+++ b/FrequentFlyerTests/HTTP/HTTPClientSpec.swift
@@ -24,6 +24,14 @@ class HTTPClientSpec: QuickSpec {
                         http$ = subject.perform(request: request)
                         result = StreamResult(http$)
                     }
+                    
+                    it("shows the spinner while the request is loading") {
+                        expect(UIApplication.shared.isNetworkActivityIndicatorVisible).to(beTrue())
+                    }
+                    
+                    it("hides the spinner when the request is complete") {
+                        expect(UIApplication.shared.isNetworkActivityIndicatorVisible).toEventually(beFalse())
+                    }
 
                     it("calls the completion handler with the response data") {
                         let testServerData = "{\"success\" : \"yeah\" }".data(using: String.Encoding.utf8)


### PR DESCRIPTION
RxCocoa has a nice built-in way of using URLSession in a reactive way that does most of what HTTPClient does, including mapping responses to useful errors. It also handles cancellation nicely by calling cancel() on the data task when the observable is disposed. (Implementation is here: https://github.com/ReactiveX/RxSwift/blob/master/RxCocoa/Foundation/URLSession%2BRx.swift)

